### PR TITLE
Refactor the RC workflow

### DIFF
--- a/.github/workflows/cut-release-candidate.yaml
+++ b/.github/workflows/cut-release-candidate.yaml
@@ -1,11 +1,15 @@
-name: Create Test RC Package
+name: Cut a Release Candidate
 
 on:
-  workflow_dispatch:  # Keep manual trigger
+  workflow_dispatch:
     inputs:
       version:
         description: 'Version (e.g. 0.1.1rc2, 0.1.1.dev20250201)'
         required: true
+        type: string
+      commit_id:
+        description: 'Commit ID for "cut" (default: origin/main)'
+        required: false
         type: string
 #  schedule:
 #    - cron: "0 0 * * *"  # Run every day at midnight
@@ -20,12 +24,19 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@v4
-    - uses: ./actions/upload-test-packages
+    - uses: ./actions/test-and-cut
       with:
         version: ${{ inputs.version }}
+        commit_id: ${{ inputs.commit_id }}
         fireworks_api_key: ${{ secrets.FIREWORKS_API_KEY }}
         together_api_key: ${{ secrets.TOGETHER_API_KEY }}
         tavily_search_api_key: ${{ secrets.TAVILY_SEARCH_API_KEY }}
+        # TODO: this will expire in 90 days; we should figure out a 
+        # GitHub App setup that can be used instead
+        github_token: ${{ secrets.LLAMA_REPOS_PAT }}        
+    - uses: ./actions/upload-packages-and-tag
+      with:
+        version: ${{ inputs.version }}
         # TODO: this will expire in 90 days; we should figure out a 
         # GitHub App setup that can be used instead
         github_token: ${{ secrets.LLAMA_REPOS_PAT }}        

--- a/.github/workflows/cut-release-candidate.yaml
+++ b/.github/workflows/cut-release-candidate.yaml
@@ -15,12 +15,11 @@ on:
 #    - cron: "0 0 * * *"  # Run every day at midnight
 
 jobs:
-  publish-to-testpypi:
+  test-and-cut:
     runs-on: ubuntu-latest
     environment:
       name: testrelease
     permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
       contents: read
     steps:
     - uses: actions/checkout@v4
@@ -34,6 +33,18 @@ jobs:
         # TODO: this will expire in 90 days; we should figure out a 
         # GitHub App setup that can be used instead
         github_token: ${{ secrets.LLAMA_REPOS_PAT }}        
+
+  upload-packages-and-tag:
+    needs:
+      - test-and-cut
+    environment:
+      name: testrelease
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+      contents: read
+    steps:
+    - uses: actions/checkout@v4
     - uses: ./actions/upload-packages-and-tag
       with:
         version: ${{ inputs.version }}
@@ -43,7 +54,7 @@ jobs:
 
   test-published-package:
     needs:
-      - publish-to-testpypi
+      - upload-packages-and-tag
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/actions/test-and-cut/action.yaml
+++ b/actions/test-and-cut/action.yaml
@@ -1,11 +1,11 @@
-name: 'Upload test packages to test.pypi'
-description: 'Upload test packages to test.pypi'
+name: 'Cut a Release Candidate'
+description: 'Cut a release candidate branch'
 inputs:
   version:
     description: 'Version of the package to publish'
     required: true
-  branch:
-    description: 'Git branch to publish from'
+  commit_id:
+    description: 'Commit ID for "cut" (default: origin/main)'
     required: false
     default: ''
   fireworks_api_key:
@@ -50,7 +50,7 @@ runs:
       shell: bash
       env:
         VERSION: ${{ inputs.version }}
-        BRANCH: ${{ inputs.branch }}
+        COMMIT_ID: ${{ inputs.commit_id }}
         TOGETHER_API_KEY: ${{ inputs.together_api_key }}
         TAVILY_SEARCH_API_KEY: ${{ inputs.tavily_search_api_key }}
         FIREWORKS_API_KEY: ${{ inputs.fireworks_api_key }}
@@ -58,10 +58,3 @@ runs:
       run: |
         chmod +x ${{ github.action_path }}/main.sh
         ${{ github.action_path }}/main.sh
-
-# Example usage in workflow:
-# - uses: meta-llama/llama-stack-ops/actions/upload-test-packages@main
-#   with:
-#     version: 0.1.1rc2
-#     branch: main
-#     pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/actions/upload-packages-and-tag/action.yaml
+++ b/actions/upload-packages-and-tag/action.yaml
@@ -1,0 +1,34 @@
+name: 'Upload test packages to test.pypi and tag'
+inputs:
+  version:
+    description: 'Version of the package to publish'
+    required: true
+  github_token:
+    description: 'Personal Access Token (PAT) with access to all llama repositories'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+    - uses: astral-sh/setup-uv@v5
+      with:
+        python-version: '3.10'
+        enable-cache: false
+
+    - name: Configure Git
+      shell: bash
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+    - name: Build and publish
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+      run: |
+        chmod +x ${{ github.action_path }}/main.sh
+        ${{ github.action_path }}/main.sh

--- a/actions/upload-packages-and-tag/main.sh
+++ b/actions/upload-packages-and-tag/main.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+if [ -z "$VERSION" ]; then
+  echo "You must set the VERSION environment variable" >&2
+  exit 1
+fi
+GITHUB_TOKEN=${GITHUB_TOKEN:-}
+
+
+TEMPLATE=fireworks
+
+set -euo pipefail
+set -x
+
+TMPDIR=$(mktemp -d)
+cd $TMPDIR
+
+uv venv -p python3.10
+source .venv/bin/activate
+
+uv pip install twine
+
+REPOS=(models stack-client-python stack)
+for repo in "${REPOS[@]}"; do
+  git clone --depth 1 --branch "rc-$VERSION" "https://x-access-token:${GITHUB_TOKEN}@github.com/meta-llama/llama-$repo.git"
+  cd llama-$repo
+
+  echo "Building package..."
+  uv build -q
+  uv pip install dist/*.whl
+
+  echo "Merging rc-$VERSION into main"
+  git checkout -b main origin/main
+  git merge --ff-only "rc-$VERSION"
+  echo "Tagging llama-$repo at version $VERSION"
+  git tag -a "v$VERSION" -m "Release version $VERSION"
+
+  echo "Uploading llama-$repo to testpypi"
+  python -m twine upload \
+    --repository-url https://test.pypi.org/legacy/ \
+    --skip-existing \
+    dist/*.whl dist/*.tar.gz
+
+  echo "Pushing tag for llama-$repo"
+  git push "https://x-access-token:${GITHUB_TOKEN}@github.com/meta-llama/llama-$repo.git" "v$VERSION"
+
+  cd ..
+done

--- a/actions/upload-packages-and-tag/main.sh
+++ b/actions/upload-packages-and-tag/main.sh
@@ -22,15 +22,21 @@ uv pip install twine
 
 REPOS=(models stack-client-python stack)
 for repo in "${REPOS[@]}"; do
-  git clone --depth 1 --branch "rc-$VERSION" "https://x-access-token:${GITHUB_TOKEN}@github.com/meta-llama/llama-$repo.git"
+  git clone --depth 10 "https://x-access-token:${GITHUB_TOKEN}@github.com/meta-llama/llama-$repo.git"
   cd llama-$repo
 
   echo "Building package..."
+  git fetch origin "rc-$VERSION":"rc-$VERSION"
+  git checkout "rc-$VERSION"
+
+  PYPROJECT_VERSION=$(cat pyproject.toml | grep version)
+  echo "version to build: $PYPROJECT_VERSION"
+
   uv build -q
   uv pip install dist/*.whl
 
   echo "Merging rc-$VERSION into main"
-  git checkout -b main origin/main
+  git checkout main
   git merge --ff-only "rc-$VERSION"
   echo "Tagging llama-$repo at version $VERSION"
   git tag -a "v$VERSION" -m "Release version $VERSION"


### PR DESCRIPTION
A few enhancements:

- allow for a commit_id input so you can cut at any point from the UI
- split it into two pieces (test and create a cut)
- cut actually creates a branch now which has the version-bump commit
- upload packages, then merge cut branch to main and push tags
