### PR TITLE
generate nightly builds at 1145

### DIFF
--- a/.github/workflows/publish-dockers.yaml
+++ b/.github/workflows/publish-dockers.yaml
@@ -1,6 +1,8 @@
 name: Publish Docker images
 
 on:
+  schedule:
+    - cron: '45 23 * * *'  # Every day at 11:45
   workflow_dispatch:  # Keep manual trigger
     inputs:
       version:
@@ -14,6 +16,7 @@ on:
 
 jobs:
   publish-docker-images:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -23,3 +26,18 @@ jobs:
         templates: ${{ inputs.templates }}
         dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
         dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  publish-nightly-docker-images:
+    if: ${{ github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set version variable
+      id: set_version
+      run: echo "VERSION=nightly-$(date +'%Y%m%d')" >> $GITHUB_ENV
+    - uses: ./actions/publish-dockers
+      with:
+        templates: "ollama, together, fireworks, bedrock, remote-vllm, tgi, meta-reference-gpu"
+        dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+        dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+        version: ${{ env.VERSION }}

--- a/.github/workflows/test-maybe-cut.yaml
+++ b/.github/workflows/test-maybe-cut.yaml
@@ -1,0 +1,46 @@
+name: Test and Possibly Cut a Branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_id:
+        description: 'Commit ID to test at'
+        required: true
+      version:
+        description: 'Version (e.g. 0.1.1rc2); if optional, will not cut a branch'
+        required: false
+        type: string
+#  schedule:
+#    - cron: "0 0 * * *"  # Run every day at midnight
+
+jobs:
+  test-and-maybe-cut:
+    runs-on: ubuntu-latest
+    environment:
+      name: testrelease
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set version if not provided
+      id: version
+      run: |
+        if [ -z "${{ inputs.version }}" ]; then
+          echo "value=0.0.0.dev$(date +%Y%m%d%H%M%S)" >> $GITHUB_OUTPUT
+          echo "only_test=true" >> $GITHUB_OUTPUT
+        else
+          echo "value=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          echo "only_test=false" >> $GITHUB_OUTPUT
+        fi
+      shell: bash
+    - uses: ./actions/test-and-cut
+      with:
+        version: ${{ steps.version.outputs.value }}
+        commit_id: ${{ inputs.commit_id }}
+        only_test_dont_cut: ${{ steps.version.outputs.only_test }}
+        fireworks_api_key: ${{ secrets.FIREWORKS_API_KEY }}
+        together_api_key: ${{ secrets.TOGETHER_API_KEY }}
+        tavily_search_api_key: ${{ secrets.TAVILY_SEARCH_API_KEY }}
+        # TODO: this will expire in 90 days; we should figure out a 
+        # GitHub App setup that can be used instead
+        github_token: ${{ secrets.LLAMA_REPOS_PAT }}        

--- a/actions/publish-dockers-nightly/actions.yaml
+++ b/actions/publish-dockers-nightly/actions.yaml
@@ -1,10 +1,6 @@
 name: 'Publish Docker images'
-description: 'Publish Docker images; PyPI packages must already be published'
+description: 'Publish Docker images; Using the main branch'
 inputs:
-  version:
-    description: 'Version number (e.g. 0.1.1rc2, 0.1.1.dev20250201)'
-    required: true
-    type: string
   templates:
     description: 'Optional comma-separated templates to publish'
     required: false
@@ -34,9 +30,7 @@ runs:
         username: ${{ inputs.dockerhub_username }}
         password: ${{ inputs.dockerhub_token }}
 
-
     - name: Pull the main branch of llama-stack
-      if: startsWith(github.event.inputs.version, 'nightly-')
       uses: actions/checkout@v2
       with:
         ref: 'main'
@@ -51,9 +45,3 @@ runs:
       run: |
         chmod +x ${{ github.action_path }}/main.sh
         ${{ github.action_path }}/main.sh
-
-# Example usage in workflow:
-# - uses: meta-llama/llama-stack-ops/actions/commit-final-packages@main
-#   with:
-#     version: '1.0.0'
-#     pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/actions/publish-dockers/main.sh
+++ b/actions/publish-dockers/main.sh
@@ -4,71 +4,92 @@ if [ -z "$VERSION" ]; then
   echo "You must set the VERSION environment variable" >&2
   exit 1
 fi
+
 TEMPLATES=${TEMPLATES:-}
+IS_NIGHTLY=false
+
+if [[ "$VERSION" == nightly-* ]]; then
+  IS_NIGHTLY=true
+fi
 
 set -euo pipefail
 
-release_exists() {
-  local source=$1
-  releases=$(curl -s https://${source}.org/pypi/llama-stack/json | jq -r '.releases | keys[]')
-  for release in $releases; do
-    if [ x"$release" = x"$VERSION" ]; then
-      return 0
-    fi
-  done
-  return 1
-}
-
-
-if release_exists "test.pypi"; then
-  echo "Version $VERSION found in test.pypi"
-  PYPI_SOURCE="testpypi" 
-elif release_exists "pypi"; then
-  echo "Version $VERSION found in pypi"
-  PYPI_SOURCE="pypi"
-else
-  echo "Version $VERSION not found in either test.pypi or pypi" >&2
-  exit 1
+# Common setup for both scripts
+if [ "$IS_NIGHTLY" = true ]; then
+  cd llama-stack
 fi
 
 set -x
-TMPDIR=$(mktemp -d)
-cd $TMPDIR
 uv venv -p python3.10
 source .venv/bin/activate
 
-uv pip install --index-url https://test.pypi.org/simple/ \
-  --extra-index-url https://pypi.org/simple \
-  --index-strategy unsafe-best-match \
-  llama-stack==${VERSION} llama-models==${VERSION} llama-stack-client==${VERSION}
+if [ "$IS_NIGHTLY" = true ]; then
+  pip install -U .
+else
+  release_exists() {
+    local source=$1
+    releases=$(curl -s https://${source}.org/pypi/llama-stack/json | jq -r '.releases | keys[]')
+    for release in $releases; do
+      if [ x"$release" = x"$VERSION" ]; then
+        return 0
+      fi
+    done
+    return 1
+  }
+
+  if release_exists "test.pypi"; then
+    echo "Version $VERSION found in test.pypi"
+    PYPI_SOURCE="testpypi"
+  elif release_exists "pypi"; then
+    echo "Version $VERSION found in pypi"
+    PYPI_SOURCE="pypi"
+  else
+    echo "Version $VERSION not found in either test.pypi or pypi" >&2
+    exit 1
+  fi
+
+  uv pip install --index-url https://test.pypi.org/simple/ \
+    --extra-index-url https://pypi.org/simple \
+    --index-strategy unsafe-best-match \
+    llama-stack==${VERSION} llama-models==${VERSION} llama-stack-client==${VERSION}
+fi
 
 which llama
 llama stack list-apis
-
 
 build_and_push_docker() {
   template=$1
 
   echo "Building and pushing docker for template $template"
-  if [ "$PYPI_SOURCE" = "testpypi" ]; then
-    TEST_PYPI_VERSION=${VERSION} llama stack build --template $template --image-type container
+
+  if [ "$IS_NIGHTLY" = true ]; then
+    USE_COPY_NOT_MOUNT=true LLAMA_STACK_DIR=. llama stack build --template $template --image-type container
   else
-    PYPI_VERSION=${VERSION} llama stack build --template $template --image-type container
+    if [ "$PYPI_SOURCE" = "testpypi" ]; then
+      TEST_PYPI_VERSION=${VERSION} llama stack build --template $template --image-type container
+    else
+      PYPI_VERSION=${VERSION} llama stack build --template $template --image-type container
+    fi
   fi
+
   docker images
 
   echo "Pushing docker image"
-  if [ "$PYPI_SOURCE" = "testpypi" ]; then
-    docker tag distribution-$template:test-${VERSION} llamastack/distribution-$template:test-${VERSION}
-    docker push llamastack/distribution-$template:test-${VERSION}
-  else
-    docker tag distribution-$template:${VERSION} llamastack/distribution-$template:${VERSION}
-    docker tag distribution-$template:${VERSION} llamastack/distribution-$template:latest
+  if [ "$IS_NIGHTLY" = true ]; then
+    docker tag distribution-$template:dev llamastack/distribution-$template:${VERSION}
     docker push llamastack/distribution-$template:${VERSION}
-    docker push llamastack/distribution-$template:latest
+  else
+    if [ "$PYPI_SOURCE" = "testpypi" ]; then
+      docker tag distribution-$template:test-${VERSION} llamastack/distribution-$template:test-${VERSION}
+      docker push llamastack/distribution-$template:test-${VERSION}
+    else
+      docker tag distribution-$template:${VERSION} llamastack/distribution-$template:${VERSION}
+      docker tag distribution-$template:${VERSION} llamastack/distribution-$template:latest
+      docker push llamastack/distribution-$template:${VERSION}
+      docker push llamastack/distribution-$template:latest
+    fi
   fi
 }
-
 
 if [ -z "$TEMPLATES" ]; then
   TEMPLATES=(ollama together fireworks bedrock remote-vllm tgi meta-reference-gpu)

--- a/actions/release-final-package/main.sh
+++ b/actions/release-final-package/main.sh
@@ -54,23 +54,27 @@ source .venv/bin/activate
 uv pip install twine
 
 for repo in models stack-client-python stack; do  
-  git clone --depth 1 "https://x-access-token:${GITHUB_TOKEN}@github.com/meta-llama/llama-$repo.git"
+  git clone --depth 10 "https://x-access-token:${GITHUB_TOKEN}@github.com/meta-llama/llama-$repo.git"
   cd llama-$repo
-  git checkout -b release-$RELEASE_VERSION v$RC_VERSION
+  git fetch origin refs/tags/v${RC_VERSION}:refs/tags/v${RC_VERSION}
+  git checkout -b release-$RELEASE_VERSION refs/tags/v${RC_VERSION}
 
+  # TODO: this is dangerous use uvx toml-cli toml set project.version $RELEASE_VERSION instead of this
+  # cringe perl code
+  perl -pi -e "s/version = .*$/version = \"$RELEASE_VERSION\"/" pyproject.toml
   perl -pi -e "s/llama-models>=.*,/llama-models>=$RELEASE_VERSION\",/" pyproject.toml
   perl -pi -e "s/llama-stack-client>=.*,/llama-stack-client>=$RELEASE_VERSION\",/" pyproject.toml
 
-  perl -pi -e "s/version = .*$/version = \"$RELEASE_VERSION\"/" pyproject.toml
   if [ -f "src/llama_stack_client/_version.py" ]; then
     perl -pi -e "s/__version__ = .*$/__version__ = \"$RELEASE_VERSION\"/" src/llama_stack_client/_version.py
   fi
 
   uv export --frozen --no-hashes --no-emit-project --output-file=requirements.txt
-  git commit -a -m "Bump version to $RELEASE_VERSION"
+  git commit -a -m "Bump version to $RELEASE_VERSION" --amend
   git tag -a "v$RELEASE_VERSION" -m "Release version $RELEASE_VERSION"
 
-  uv build
+  uv build -q
+  uv pip install dist/*.whl
   cd ..
 done
 
@@ -84,14 +88,6 @@ done
 # git tag -a "v$RELEASE_VERSION" -m "Release version $RELEASE_VERSION"
 # cd ..
 
-echo "Installing llama models"
-uv pip install llama-models/dist/llama_models-$RELEASE_VERSION-py3*.whl
-
-echo "Installing llama stack client"
-uv pip install llama-stack-client-python/dist/llama_stack_client-$RELEASE_VERSION-py3*.whl
-
-echo "Installing llama stack"
-uv pip install llama-stack/dist/llama_stack-$RELEASE_VERSION-py3*.whl
 which llama
 llama model prompt-format -m Llama3.2-11B-Vision-Instruct
 llama model list
@@ -113,7 +109,9 @@ for repo in models stack-client-python stack; do
 
   # push the new commit to main and push the tag
   echo "Pushing tag v$RELEASE_VERSION for $repo"
-  git push "https://x-access-token:${GITHUB_TOKEN}@github.com/meta-llama/llama-$repo.git" "release-$RELEASE_VERSION:main"
+  git checkout main
+  git rebase --onto main $(git merge-base main release-$RELEASE_VERSION) release-$RELEASE_VERSION
+  git push "https://x-access-token:${GITHUB_TOKEN}@github.com/meta-llama/llama-$repo.git" "main"
   git push "https://x-access-token:${GITHUB_TOKEN}@github.com/meta-llama/llama-$repo.git" "v$RELEASE_VERSION"
   cd ..
 done

--- a/actions/test-and-cut/action.yaml
+++ b/actions/test-and-cut/action.yaml
@@ -8,6 +8,10 @@ inputs:
     description: 'Commit ID for "cut" (default: origin/main)'
     required: false
     default: ''
+  only_test_dont_cut:
+    description: 'Do not cut a branch, only run tests (default: false)'
+    required: false
+    default: 'false'
   fireworks_api_key:
     description: 'Fireworks API key'
     required: true
@@ -51,6 +55,7 @@ runs:
       env:
         VERSION: ${{ inputs.version }}
         COMMIT_ID: ${{ inputs.commit_id }}
+        ONLY_TEST_DONT_CUT: ${{ inputs.only_test_dont_cut }}
         TOGETHER_API_KEY: ${{ inputs.together_api_key }}
         TAVILY_SEARCH_API_KEY: ${{ inputs.tavily_search_api_key }}
         FIREWORKS_API_KEY: ${{ inputs.fireworks_api_key }}

--- a/actions/upload-packages-and-tag/main.sh
+++ b/actions/upload-packages-and-tag/main.sh
@@ -40,10 +40,6 @@ for repo in "${REPOS[@]}"; do
   echo "Tagging llama-$repo at version $VERSION (not pushing yet)"
   git tag -a "v$VERSION" -m "Release version $VERSION"
 
-  echo "Merging rc-$VERSION into main"
-  git checkout main
-  git merge --ff-only "rc-$VERSION"
-
   echo "Uploading llama-$repo to testpypi"
   python -m twine upload \
     --repository-url https://test.pypi.org/legacy/ \


### PR DESCRIPTION
closes #6 

We should have nightly image builds due to how quickly the project is moving

You should see images here when testing with my repo https://hub.docker.com/u/cooktheryan

action https://github.com/cooktheryan/llama-stack-ops/actions/runs/13593194260
then switching the image back to what it will be in the main repo https://github.com/cooktheryan/llama-stack-ops/actions/runs/13593780277/job/38005942782