### PR TITLE
Workflow for Building Playground Image

### DIFF
--- a/.github/workflows/build_playground.yml
+++ b/.github/workflows/build_playground.yml
@@ -28,6 +28,10 @@ jobs:
           token: ${{ secrets.LLAMA_STACK_REPO_TOKEN }}
           path: configs
           ref: main # May wan to make this an input in the future
+      - name: Print Directory
+        run: ls -R
+      
+      
 
       - name: Login to Image Registry
         uses: docker/login-action@v3

--- a/.github/workflows/build_playground.yml
+++ b/.github/workflows/build_playground.yml
@@ -1,0 +1,48 @@
+name: "Build and Push Playground Image"
+
+env:
+  IMAGE_NAME: "jland/llama-stack-playground"
+  IMAGE_TAG_LATEST: "latest"
+  REGISTRY_URL: "quay.io" # Replace with your registry URL
+  
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version (e.g. 0.1.1rc2, 0.1.1.dev20250201)'
+        required: true
+        type: string
+
+jobs:
+  #################################
+  #### Deploy Playground Image ####
+  #################################
+  deploy-image:
+    name: Validate and Deploy Playground Image
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          repository: jland-redhat/llama-stack #TODO: Change This
+          token: ${{ secrets.LLAMA_STACK_REPO_TOKEN }}
+          path: configs
+          ref: main # May wan to make this an input in the future
+
+      - name: Login to Image Registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY_URL }}
+
+      # Build and Push image to registry with tag matching the Git Tag and latest
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./llama_stack/distribution/ui/
+          file: ./llama_stack/distribution/ui/Containerfile
+          push: true
+          tags: ${{ env.REGISTRY_URL }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}, ${{ env.REGISTRY_URL }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG_LATEST }}
+          ulimit: nofile=4096

--- a/.github/workflows/build_playground.yml
+++ b/.github/workflows/build_playground.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           repository: jland-redhat/llama-stack #TODO: Change This
           token: ${{ secrets.LLAMA_STACK_REPO_TOKEN }}
-          path: configs
           ref: main # May wan to make this an input in the future
       - name: Print Directory
         run: ls -R
@@ -47,5 +46,5 @@ jobs:
           context: ./llama_stack/distribution/ui/
           file: ./llama_stack/distribution/ui/Containerfile
           push: true
-          tags: ${{ env.REGISTRY_URL }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}, ${{ env.REGISTRY_URL }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG_LATEST }}
+          tags: ${{ env.REGISTRY_URL }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}, ${{ env.REGISTRY_URL }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG_LATEST }}
           ulimit: nofile=4096

--- a/.github/workflows/build_playground.yml
+++ b/.github/workflows/build_playground.yml
@@ -27,9 +27,6 @@ jobs:
           repository: jland-redhat/llama-stack #TODO: Change This
           token: ${{ secrets.LLAMA_STACK_REPO_TOKEN }}
           ref: main # May wan to make this an input in the future
-      - name: Print Directory
-        run: ls -R
-      
       
 
       - name: Login to Image Registry

--- a/.github/workflows/build_playground.yml
+++ b/.github/workflows/build_playground.yml
@@ -4,7 +4,7 @@ env:
   IMAGE_NAME: "jland/llama-stack-playground"
   IMAGE_TAG_LATEST: "latest"
   REGISTRY_URL: "quay.io" # Replace with your registry URL
-  
+
 on:
   workflow_dispatch:
     inputs:
@@ -20,7 +20,6 @@ jobs:
   deploy-image:
     name: Validate and Deploy Playground Image
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
# What does this PR do?

Also adds a workflow for deploying playground image to a docker registry.

> [!Note]  
> Dependent on this PR being merged:
> https://github.com/meta-llama/llama-stack/pull/1256

> [!Warning]  
> Currently this is pointing to my personal quay repo but that is something I can change once a repo is created for the playground. Just let me know the values.
> Also the secret values for `REGISTRY_USERNAME` and `REGISTRY_PASSWORD` you will need to be updated in the project's settings. 

## Test Plan

Validated the image deploy steps by adding a tag in my personal repo seen here:
https://github.com/jland-redhat/llama-stack-ops/actions/runs/13677425633

Resulting in this image:
https://quay.io/repository/jland/llama-stack-playground?tab=tags

Which I tested on my local Openshift Instance using this helm chart:
https://github.com/Jaland/llama-stack-helm/tree/main/llama-stack

[//]: # (## Documentation)
