### PR TITLE
add      --prerelease=allow

### DIFF
--- a/actions/test-published-package/main.sh
+++ b/actions/test-published-package/main.sh
@@ -25,6 +25,7 @@ while [ $attempt -le $max_attempts ]; do
   echo "Attempt $attempt of $max_attempts to install package..."
   if uv pip install --no-cache \
     --index-strategy unsafe-best-match \
+    --prerelease=allow \
     --index-url https://pypi.org/simple/ \
     --extra-index-url https://test.pypi.org/simple/ \
     llama-stack==${VERSION}; then


### PR DESCRIPTION

Summary:
fixes https://github.com/meta-llama/llama-stack-ops/actions/runs/13730043559/job/38405743871


+ uv pip install --no-cache --index-strategy unsafe-best-match --index-url https://pypi.org/simple/ --extra-index-url https://test.pypi.org/simple/ llama-stack==0.1.6rc7
  × No solution found when resolving dependencies:
  ╰─▶ Because only llama-stack-client<0.1.6rc7 is available and
      llama-stack==0.1.6rc7 depends on llama-stack-client>=0.1.6rc7, we can
      conclude that llama-stack==0.1.6rc7 cannot be used.
      And because you require llama-stack==0.1.6rc7, we can conclude that your
      requirements are unsatisfiable.

      hint: `llama-stack-client` was requested with a pre-release marker
      (e.g., llama-stack-client>=0.1.6rc7), but pre-releases weren't enabled
      (try: `--prerelease=allow`)

Test Plan:
