### PR TITLE
feat: build and publish to npm workflow

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -25,6 +25,7 @@ jobs:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
+          cache-dependency-path: './llama-stack-client-typescript/yarn.lock'
 
       - name: Install Yarn
         run: npm install -g yarn

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -1,13 +1,12 @@
 name: Publish Package to NPM
 
 on:
-  # workflow_dispatch:  # Keep manual trigger
-  #   inputs:
-  #     version:
-  #       description: 'Version number (e.g. 0.1.1rc2, 0.1.1.dev20250201)'
-  #       required: true
-  #       type: string
-  push:
+  workflow_dispatch:  # Keep manual trigger
+    inputs:
+      version:
+        description: 'Version number (e.g. 0.1.1rc2, 0.1.1.dev20250201)'
+        required: true
+        type: string
 
 jobs:
   build-and-publish:
@@ -19,6 +18,6 @@ jobs:
       - name: Publish to NPM
         uses: ./actions/publish-npm
         with:
-          version: 0.1.6rc3
+          version: ${{ inputs.version }}
           npm_token: ${{ secrets.NPM_TOKEN }}
           github_token: ${{ secrets.LLAMA_REPOS_PAT }}

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -1,12 +1,13 @@
 name: Publish Package to NPM
 
 on:
-  workflow_dispatch:  # Keep manual trigger
-    inputs:
-      version:
-        description: 'Version number (e.g. 0.1.1rc2, 0.1.1.dev20250201)'
-        required: true
-        type: string
+  # workflow_dispatch:  # Keep manual trigger
+  #   inputs:
+  #     version:
+  #       description: 'Version number (e.g. 0.1.1rc2, 0.1.1.dev20250201)'
+  #       required: true
+  #       type: string
+  push:
 
 jobs:
   build-and-publish:
@@ -14,42 +15,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        
+      - name: Publish to NPM
+        uses: ./actions/publish-npm
         with:
-          repository: meta-llama/llama-stack-client-typescript  # Replace with the actual owner/repo-name
-          path: ./llama-stack-client-typescript
-          token: ${{ secrets.LLAMA_REPOS_PAT }}
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-          registry-url: 'https://registry.npmjs.org'
-          cache: 'yarn'
-          cache-dependency-path: './llama-stack-client-typescript/yarn.lock'
-
-      - name: Install Yarn
-        run: npm install -g yarn
-
-      - name: Build and Publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          cd llama-stack-client-typescript
-          if [[ "${{ inputs.version }}" == *"rc"* ]]; then
-            yarn version --new-version ${{ inputs.version }} -m "Bump version to ${{ inputs.version }}" --no-git-tag-version
-          else
-            yarn version --new-version ${{ inputs.version }} -m "Bump version to ${{ inputs.version }}"
-          fi
-          yarn install
-          yarn build
-          cd dist
-          if [[ "${{ inputs.version }}" == *"rc"* ]]; then
-            yarn publish --tag rc --non-interactive --access public
-          else
-            yarn publish --non-interactive --access public
-            git config --global user.email "github-actions@github.com"
-            git config --global user.name "GitHub Actions"
-            git commit -a -m "Bump version to ${{ inputs.version }}" --amend
-            git push origin HEAD:main --force
-          fi
-          cd ..
+          version: 0.1.6rc2
+          npm_token: ${{ secrets.NPM_TOKEN }}
+          github_token: ${{ secrets.LLAMA_REPOS_PAT }}

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -35,9 +35,18 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd llama-stack-client-typescript
-          yarn version --new-version ${{ inputs.version }} -m "Bump version to ${{ inputs.version }}" --no-git-tag-version
+          if [[ "${{ inputs.version }}" == *"rc"* ]]; then
+            yarn version --new-version ${{ inputs.version }} -m "Bump version to ${{ inputs.version }}" --no-git-tag-version
+          else
+            yarn version --new-version ${{ inputs.version }} -m "Bump version to ${{ inputs.version }}"
+          fi
           yarn install
           yarn build
           cd dist
-          yarn publish --tag rc --non-interactive --access public
+          if [[ "${{ inputs.version }}" == *"rc"* ]]; then
+            yarn publish --tag rc --non-interactive --access public
+          else
+            yarn publish --non-interactive --access public
+            git commit -a -m "Bump version to ${{ inputs.version }}" --amend
+          fi
           cd ..

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -1,0 +1,42 @@
+name: Publish Package to NPM
+
+on:
+#   release:
+#     types: [created]
+#   # Optionally, you can also trigger this workflow manually
+#   workflow_dispatch:
+  push:
+
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          repository: meta-llama/llama-stack-client-typescript  # Replace with the actual owner/repo-name
+          path: ./llama-stack-client-typescript
+          token: ${{ secrets.LLAMA_REPOS_PAT }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'yarn'
+
+      - name: Install Yarn
+        run: npm install -g yarn
+
+      - name: Build and Publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          cd llama-stack-client-typescript
+          yarn version --new-version 0.1.6rc2 -m "Bump version to 0.1.6rc2" --no-git-tag-version
+          yarn install
+          yarn build
+          cd dist
+          yarn publish --tag rc --non-interactive --access public
+          cd ..

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -1,12 +1,12 @@
 name: Publish Package to NPM
 
 on:
-#   release:
-#     types: [created]
-#   # Optionally, you can also trigger this workflow manually
-#   workflow_dispatch:
-  push:
-
+  workflow_dispatch:  # Keep manual trigger
+    inputs:
+      version:
+        description: 'Version number (e.g. 0.1.1rc2, 0.1.1.dev20250201)'
+        required: true
+        type: string
 
 jobs:
   build-and-publish:
@@ -35,7 +35,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd llama-stack-client-typescript
-          yarn version --new-version 0.1.6rc2 -m "Bump version to 0.1.6rc2" --no-git-tag-version
+          yarn version --new-version ${{ inputs.version }} -m "Bump version to ${{ inputs.version }}" --no-git-tag-version
           yarn install
           yarn build
           cd dist

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         
       - name: Publish to NPM
         uses: ./actions/publish-npm

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -47,6 +47,9 @@ jobs:
             yarn publish --tag rc --non-interactive --access public
           else
             yarn publish --non-interactive --access public
+            git config --global user.email "github-actions@github.com"
+            git config --global user.name "GitHub Actions"
             git commit -a -m "Bump version to ${{ inputs.version }}" --amend
+            git push origin HEAD:main --force
           fi
           cd ..

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -19,6 +19,6 @@ jobs:
       - name: Publish to NPM
         uses: ./actions/publish-npm
         with:
-          version: 0.1.6rc2
+          version: 0.1.6rc3
           npm_token: ${{ secrets.NPM_TOKEN }}
           github_token: ${{ secrets.LLAMA_REPOS_PAT }}

--- a/actions/publish-npm/action.yaml
+++ b/actions/publish-npm/action.yaml
@@ -1,0 +1,47 @@
+name: Publish Package to NPM
+
+on:
+  workflow_dispatch:  # Keep manual trigger
+    inputs:
+      version:
+        description: 'Version number (e.g. 0.1.1rc2, 0.1.1.dev20250201)'
+        required: true
+        type: string
+      npm_token:
+        description: 'NPM token'
+        required: true
+        type: string
+      github_token:
+        description: 'Personal Access Token (PAT) with access to all llama repositories'
+        required: true
+        type: string
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          repository: meta-llama/llama-stack-client-typescript  # Replace with the actual owner/repo-name
+          path: ./llama-stack-client-typescript
+          token: ${{ inputs.github_token }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'yarn'
+          cache-dependency-path: './llama-stack-client-typescript/yarn.lock'
+
+      - name: Install Yarn
+        run: npm install -g yarn
+
+      - name: Build and Publish
+        env:
+          NODE_AUTH_TOKEN: ${{ inputs.npm_token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          chmod +x ${{ github.action_path }}/main.sh
+          ${{ github.action_path }}/main.sh

--- a/actions/publish-npm/action.yaml
+++ b/actions/publish-npm/action.yaml
@@ -1,47 +1,44 @@
 name: Publish Package to NPM
 
-on:
-  workflow_dispatch:  # Keep manual trigger
-    inputs:
-      version:
-        description: 'Version number (e.g. 0.1.1rc2, 0.1.1.dev20250201)'
-        required: true
-        type: string
-      npm_token:
-        description: 'NPM token'
-        required: true
-        type: string
-      github_token:
-        description: 'Personal Access Token (PAT) with access to all llama repositories'
-        required: true
-        type: string
+inputs:
+  version:
+    description: 'Version number (e.g. 0.1.1rc2, 0.1.1.dev20250201)'
+    required: true
+    type: string
+  npm_token:
+    description: 'NPM token'
+    required: true
+    type: string
+  github_token:
+    description: 'Personal Access Token (PAT) with access to all llama repositories'
+    required: true
+    type: string
 
-jobs:
-  build-and-publish:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          repository: meta-llama/llama-stack-client-typescript  # Replace with the actual owner/repo-name
-          path: ./llama-stack-client-typescript
-          token: ${{ inputs.github_token }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        repository: meta-llama/llama-stack-client-typescript
+        path: ./llama-stack-client-typescript
+        token: ${{ inputs.github_token }}
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-          registry-url: 'https://registry.npmjs.org'
-          cache: 'yarn'
-          cache-dependency-path: './llama-stack-client-typescript/yarn.lock'
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+        registry-url: 'https://registry.npmjs.org'
+        cache: 'yarn'
+        cache-dependency-path: './llama-stack-client-typescript/yarn.lock'
 
-      - name: Install Yarn
-        run: npm install -g yarn
+    - name: Install Yarn
+      run: npm install -g yarn
 
-      - name: Build and Publish
-        env:
-          NODE_AUTH_TOKEN: ${{ inputs.npm_token }}
-          VERSION: ${{ inputs.version }}
-        run: |
-          chmod +x ${{ github.action_path }}/main.sh
-          ${{ github.action_path }}/main.sh
+    - name: Build and Publish
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.npm_token }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        chmod +x ${{ github.action_path }}/main.sh
+        ${{ github.action_path }}/main.sh

--- a/actions/publish-npm/action.yaml
+++ b/actions/publish-npm/action.yaml
@@ -27,7 +27,7 @@ runs:
     - name: Set up Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '18'
+        node-version: '20'
         registry-url: 'https://registry.npmjs.org'
         cache: 'yarn'
         cache-dependency-path: './llama-stack-client-typescript/yarn.lock'

--- a/actions/publish-npm/action.yaml
+++ b/actions/publish-npm/action.yaml
@@ -33,9 +33,11 @@ runs:
         cache-dependency-path: './llama-stack-client-typescript/yarn.lock'
 
     - name: Install Yarn
+      shell: bash
       run: npm install -g yarn
 
     - name: Build and Publish
+      shell: bash
       env:
         NODE_AUTH_TOKEN: ${{ inputs.npm_token }}
         VERSION: ${{ inputs.version }}

--- a/actions/publish-npm/main.sh
+++ b/actions/publish-npm/main.sh
@@ -17,6 +17,6 @@ else
   git config --global user.email "github-actions@github.com"
   git config --global user.name "GitHub Actions"
   git commit -a -m "Bump version to $VERSION" --amend
-  git push origin HEAD:main --force
+  git push
 fi
 cd ..

--- a/actions/publish-npm/main.sh
+++ b/actions/publish-npm/main.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+cd llama-stack-client-typescript
+if [[ "$VERSION" == *"rc"* ]]; then
+  yarn version --new-version $VERSION -m "Bump version to $VERSION" --no-git-tag-version
+else
+  yarn version --new-version $VERSION -m "Bump version to $VERSION"
+fi
+yarn install
+yarn build
+cd dist
+if [[ "$VERSION" == *"rc"* ]]; then
+  yarn publish --tag rc --non-interactive --access public
+else
+  yarn publish --non-interactive --access public
+  git config --global user.email "github-actions@github.com"
+  git config --global user.name "GitHub Actions"
+  git commit -a -m "Bump version to $VERSION" --amend
+  git push origin HEAD:main --force
+fi
+cd ..


### PR DESCRIPTION
- adding a standalone workflow to build and test npm packages, as the existing workflow is too tied together with Python SDK testings, making it hard to test without python dependencies

- success workflow: https://github.com/meta-llama/llama-stack-ops/actions/runs/13731785521