### PR TITLE
feat: test-and-cut against client python commit id

### DIFF
--- a/.github/workflows/test-maybe-cut.yaml
+++ b/.github/workflows/test-maybe-cut.yaml
@@ -6,6 +6,11 @@ on:
       commit_id:
         description: 'Commit ID to test at'
         required: true
+      client_python_commit_id:
+        description: 'llama-stack-client-python commit ID to test at'
+        required: false
+        type: string
+        default: 'origin/main'
       version:
         description: 'Version (e.g. 0.1.1rc2); if optional, will not cut a branch'
         required: false
@@ -33,9 +38,11 @@ jobs:
         if [[ "${{ github.event_name }}" == "schedule" ]]; then
           echo "commit_id=origin/main" >> $GITHUB_OUTPUT
           echo "version=" >> $GITHUB_OUTPUT
+          echo "client_python_commit_id=origin/main" >> $GITHUB_OUTPUT
         else
           echo "commit_id=${{ inputs.commit_id }}" >> $GITHUB_OUTPUT
           echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          echo "client_python_commit_id=${{ inputs.client_python_commit_id }}" >> $GITHUB_OUTPUT
         fi
       shell: bash
     - name: Set version if not provided
@@ -53,6 +60,7 @@ jobs:
       with:
         version: ${{ steps.version.outputs.value }}
         commit_id: ${{ steps.inputs.outputs.commit_id }}
+        client_python_commit_id: ${{ steps.inputs.outputs.client_python_commit_id }}
         template: ${{ inputs.template }}
         only_test_dont_cut: ${{ steps.version.outputs.only_test }}
         fireworks_api_key: ${{ secrets.FIREWORKS_API_KEY }}

--- a/actions/test-and-cut/action.yaml
+++ b/actions/test-and-cut/action.yaml
@@ -8,6 +8,10 @@ inputs:
     description: 'Commit ID for "cut" (default: origin/main)'
     required: false
     default: ''
+  client_python_commit_id:
+    description: 'llama-stack-client-python commit ID for "cut" (default: origin/main)'
+    required: false
+    default: ''
   only_test_dont_cut:
     description: 'Do not cut a branch, only run tests (default: false)'
     required: false
@@ -63,6 +67,7 @@ runs:
       env:
         VERSION: ${{ inputs.version }}
         COMMIT_ID: ${{ inputs.commit_id }}
+        CLIENT_PYTHON_COMMIT_ID: ${{ inputs.client_python_commit_id }}
         TEMPLATE: ${{ inputs.template }}
         ONLY_TEST_DONT_CUT: ${{ inputs.only_test_dont_cut }}
         LLAMA_STACK_ONLY: ${{ inputs.llama_stack_only }}

--- a/actions/test-and-cut/main.sh
+++ b/actions/test-and-cut/main.sh
@@ -9,6 +9,12 @@ if [ -z "${COMMIT_ID+x}" ]; then
   exit 1
 fi
 
+if [ -z "${CLIENT_PYTHON_COMMIT_ID+x}" ]; then
+  echo "You must set the CLIENT_PYTHON_COMMIT_ID environment variable" >&2
+  exit 1
+fi
+
+
 GITHUB_TOKEN=${GITHUB_TOKEN:-}
 ONLY_TEST_DONT_CUT=${ONLY_TEST_DONT_CUT:-false}
 LLAMA_STACK_ONLY=${LLAMA_STACK_ONLY:-false}
@@ -49,6 +55,10 @@ build_packages() {
       git fetch origin "$REF"
 
       # Use FETCH_HEAD which is where the fetched commit is stored
+      git checkout -b "rc-$VERSION" FETCH_HEAD
+    elif [ "$repo" == "stack-client-python" ] && [ -n "$CLIENT_PYTHON_COMMIT_ID" ]; then
+      REF="${CLIENT_PYTHON_COMMIT_ID#origin/}"
+      git fetch origin "$REF"
       git checkout -b "rc-$VERSION" FETCH_HEAD
     else
       git checkout -b "rc-$VERSION"


### PR DESCRIPTION
- To be able to run integration test with a python client commit ID