### PR TITLE
feat: Publish arm64 images as well

### DIFF
--- a/.github/workflows/publish-dockers.yaml
+++ b/.github/workflows/publish-dockers.yaml
@@ -11,9 +11,14 @@ on:
         description: 'Optional comma-separated templates to publish'
         required: false
         type: string
+      dockerhub_organization:
+        description: 'DockerHub organization'
+        required: false
+        type: string
+        default: llamastack
 
 jobs:
-  publish-docker-images:
+  publish-docker-images-amd64:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -23,3 +28,34 @@ jobs:
         templates: ${{ inputs.templates }}
         dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
         dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+        dockerhub_organization: ${{ inputs.dockerhub_organization }}
+        arch: amd64
+
+  publish-docker-images-arm64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ./actions/publish-dockers
+      with:
+        version: ${{ inputs.version }}
+        templates: ${{ inputs.templates }}
+        dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+        dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+        dockerhub_organization: ${{ inputs.dockerhub_organization }}
+        continue_on_error: true
+        arch: arm64
+
+  publish-docker-manifest-lists:
+    needs:
+    - publish-docker-images-amd64
+    - publish-docker-images-arm64
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ./actions/publish-docker-manifest-lists
+      with:
+        version: ${{ inputs.version }}
+        templates: ${{ inputs.templates }}
+        dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+        dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+        dockerhub_organization: ${{ inputs.dockerhub_organization }}

--- a/actions/publish-docker-manifest-lists/action.yaml
+++ b/actions/publish-docker-manifest-lists/action.yaml
@@ -1,5 +1,5 @@
-name: 'Publish Docker images'
-description: 'Publish Docker images; PyPI packages must already be published'
+name: 'Publish Docker Manifest Lists'
+description: 'Publish Docker manifest lists; architecture-specific images must already be published'
 inputs:
   version:
     description: 'Version number (e.g. 0.1.1rc2, 0.1.1.dev20250201)'
@@ -22,16 +22,6 @@ inputs:
     required: false
     type: string
     default: llamastack
-  continue_on_error:
-    description: 'Whether to continue or exit when individual templates fail to build'
-    required: false
-    type: string
-    default: false
-  arch:
-    description: Architecture we're building for (amd64 or arm64)
-    required: true
-    type: string
-    default: amd64
 runs:
   using: 'composite'
   steps:
@@ -49,20 +39,12 @@ runs:
         username: ${{ inputs.dockerhub_username }}
         password: ${{ inputs.dockerhub_token }}
 
-    - name: Build and publish
+    - name: Publish manifest lists
       shell: bash
       env:
         VERSION: ${{ inputs.version }}
         TEMPLATES: ${{ inputs.templates }}
         DOCKERHUB_ORGANIZATION: ${{ inputs.dockerhub_organization }}
-        CONTINUE_ON_ERROR: ${{ inputs.continue_on_error }}
-        ARCH: ${{ inputs.arch }}
       run: |
         chmod +x ${{ github.action_path }}/main.sh
         ${{ github.action_path }}/main.sh
-
-# Example usage in workflow:
-# - uses: meta-llama/llama-stack-ops/actions/commit-final-packages@main
-#   with:
-#     version: '1.0.0'
-#     pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/actions/publish-docker-manifest-lists/main.sh
+++ b/actions/publish-docker-manifest-lists/main.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euo pipefail
+
+THIS_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+source $THIS_DIR/../publish-dockers/common.sh
+
+set -x
+
+push_manifest_list() {
+  template=$1
+
+  echo "Pushing multi-arch manifest list for template $template"
+  if [ "$PYPI_SOURCE" = "testpypi" ]; then
+    manifests="$DOCKERHUB_ORGANIZATION/distribution-$template:test-${VERSION}-amd64"
+    has_arm64_image=$(docker buildx imagetools inspect $DOCKERHUB_ORGANIZATION/distribution-$template:test-${VERSION}-arm64 > /dev/null 2>&1; echo $?)
+    if [ "$has_arm64_image" -eq 0 ]; then
+      manifests="$manifests $DOCKERHUB_ORGANIZATION/distribution-$template:test-${VERSION}-arm64"
+    fi
+    docker buildx imagetools create \
+      -t $DOCKERHUB_ORGANIZATION/distribution-$template:test-${VERSION} \
+      $manifests
+  else
+    manifests="$DOCKERHUB_ORGANIZATION/distribution-$template:${VERSION}-amd64"
+    has_arm64_image=$(docker buildx imagetools inspect $DOCKERHUB_ORGANIZATION/distribution-$template:${VERSION}-arm64 > /dev/null 2>&1; echo $?)
+    if [ "$has_arm64_image" -eq 0 ]; then
+      manifests="$manifests $DOCKERHUB_ORGANIZATION/distribution-$template:${VERSION}-arm64"
+    fi
+    docker buildx imagetools create \
+      -t $DOCKERHUB_ORGANIZATION/distribution-$template:${VERSION} \
+      $manifests
+    docker buildx imagetools create \
+      -t $DOCKERHUB_ORGANIZATION/distribution-$template:latest \
+      $manifests
+  fi
+}
+
+for template in "${TEMPLATES[@]}"; do
+  push_manifest_list $template
+done
+
+echo "Done"

--- a/actions/publish-dockers/common.sh
+++ b/actions/publish-dockers/common.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# This file is shared between the publish-dockers and
+# publish-docker-manifest-lists actions. It should only contain content
+# that is common to both actions.
+
+if [ -z "$VERSION" ]; then
+  echo "You must set the VERSION environment variable" >&2
+  exit 1
+fi
+
+DOCKERHUB_ORGANIZATION=${DOCKERHUB_ORGANIZATION:-llamastack}
+TEMPLATES=${TEMPLATES:-}
+
+if [ -z "$TEMPLATES" ]; then
+  TEMPLATES=(starter tgi meta-reference-gpu postgres-demo)
+else
+  TEMPLATES=(${TEMPLATES//,/ })
+fi
+
+release_exists() {
+  local source=$1
+  releases=$(curl -s https://${source}.org/pypi/llama-stack/json | jq -r '.releases | keys[]')
+  for release in $releases; do
+    if [ x"$release" = x"$VERSION" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+if release_exists "test.pypi"; then
+  echo "Version $VERSION found in test.pypi"
+  PYPI_SOURCE="testpypi"
+elif release_exists "pypi"; then
+  echo "Version $VERSION found in pypi"
+  PYPI_SOURCE="pypi"
+else
+  echo "Version $VERSION not found in either test.pypi or pypi" >&2
+  exit 1
+fi


### PR DESCRIPTION
## What this PR does

This adjusts the publish-dockers workflow to also publish arm64 images. It attempts to build all templates in both amd64 and arm64, but allows the arm64 builds to fail since some of our templates (specifically meta-reference-gpu) fail to build on arm64. After building and pushing the architecture-specific images, it pushes a manifest list for all the architectures we built to the default image location.

Before, we'd end up with images like `distribution-remote-vllm` that contained only the amd64 image. Now, `distribution-remote-vllm` contains a manifest list that contains both amd64 and arm64 images. We still publish single manifest, architecture-specific images at `distribution-remote-vllm-amd64` and `distribution-remote-vllm-arm64` for really old clients, someone that specifically needs an arch-specific image, and because it's the simplest way to run these GitHub workflows as individual steps where we separate arch-specific image building from manifest list publishing in GitHub Actions.

This also makes the DockerHub organization name a build parameter that defaults to `llamastack` which I used when testing this to publish the images to my own repository.

The main benefit of this change is it allows arm64 users (whether on linux arm64 or Macs using something like podman desktop) to easily run Llama Stack container images without needing to use emulation.

## Test Plan

I ran this workflow on both a pre-release and a release pypi package to verify the workflow runs without error in both cases. It properly pushes and tags amd64 and arm64 images for all default distros exception meta-reference-gpu. That distro only builds under amd64 today, and it gracefully handles the build failure for that distro under arm64 and falls back to just pushing the amd64 image. Note that nowhere are we specifically telling the workflow which images work under amd64 and which under arm64 - it just attempts to build all the templates for both, treating any amd64 build failures as fatal (because all of our bits should work under amd64) and treating and arm64 build failures as non-fatal and continuing on.

Here's a link to the set of images built for `distribution-starter` as an example of this working - https://hub.docker.com/r/bbrowning/distribution-starter/tags . I ran this workflow twice - once for a `0.2.11rc1` release to test the logic that pulls from test pypi, and once for a `0.2.11` release to test the production release logic.