### PR TITLE
update: default docker image template to reflect current supported ones

### DIFF
--- a/actions/publish-dockers/main.sh
+++ b/actions/publish-dockers/main.sh
@@ -68,7 +68,7 @@ build_and_push_docker() {
 }
 
 if [ -z "$TEMPLATES" ]; then
-  TEMPLATES=(starter tgi meta-reference-gpu postgres-demo)
+  TEMPLATES=(starter meta-reference-gpu postgres-demo nvidia open-benchmark vllm-gpu watson)
 else
   TEMPLATES=(${TEMPLATES//,/ })
 fi


### PR DESCRIPTION
input from https://github.com/meta-llama/llama-stack/tree/main/llama_stack/templates
if not give input.template when run Github Action.